### PR TITLE
docs: Document GitLab container registry usage

### DIFF
--- a/lib/modules/platform/gitlab/index.md
+++ b/lib/modules/platform/gitlab/index.md
@@ -9,12 +9,14 @@ For real runs, give the PAT these scopes:
 - `read_user`
 - `api`
 - `write_repository`
+- `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
 For dry runs, give the PAT these scopes:
 
 - `read_user`
 - `read_api`
 - `read_repository`
+- `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
 Let Renovate use your PAT by doing _one_ of the following:
 
@@ -23,6 +25,12 @@ Let Renovate use your PAT by doing _one_ of the following:
 - Set your PAT when you run Renovate in the CLI with `--token=`
 
 Remember to set `platform=gitlab` somewhere in your Renovate config file.
+
+If you're using a private [GitLab container registry](https://docs.gitlab.com/ee/user/packages/container_registry/), you must:
+
+- Set the `RENOVATE_HOST_RULES` CI variable to `[{"matchHost": "${CI_REGISTRY}","username": "${GITLAB_USER_NAME}","password": "${RENOVATE_TOKEN}"}]`.
+- Make sure the user that owns the `RENOVATE_TOKEN` PAT is a member of the corresponding GitLab projects/groups with the right permissions.
+- Make sure the `RENOVATE_TOKEN` PAT has the `read_registry` scope.
 
 ## Features awaiting implementation
 


### PR DESCRIPTION
The documented configuration does not address how Renovate can access a private GitLab container registry (for the `docker` datasource for example). This commit addresses that.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The existing GitLab integration documentation does not address how to authenticate to GitLab's container registry.
This PR fixes that.

## Context

I was trying to leverage the `docker` datasource on my private GitLab instance using [renovate-runner](https://gitlab.com/renovate-bot/renovate-runner).

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
